### PR TITLE
Add Pulsedrop AMI flags

### DIFF
--- a/pulsedrop_direct/aws-iot-core/examples-aws-handler.json
+++ b/pulsedrop_direct/aws-iot-core/examples-aws-handler.json
@@ -65,5 +65,47 @@
       "temperatureCelsius": -40,
       "status": 200
     }
+  },
+  {
+    "type": "aws-uplink",
+    "description": "Error: no response from meter",
+    "input": {
+      "PayloadData": "HP8RAAAN6AAAAAE=",
+      "WirelessDeviceId": "57728ff8-5d1d-4130-9de2-f004d8722bc2",
+      "WirelessMetadata": {
+        "LoRaWAN": {
+          "DataRate": 0,
+          "DevEui": "aaaa1111bbbb2222",
+          "FPort": 2,
+          "Frequency": 867900000,
+          "Timestamp": "2020-12-07T14:41:48Z"
+        }
+      }
+    },
+    "output": {
+      "errorMessage": "No response from meter",
+      "status": 500
+    }
+  },
+  {
+    "type": "aws-uplink",
+    "description": "Error: invalid response from meter",
+    "input": {
+      "PayloadData": "HP8RAAAN6AAAAAI=",
+      "WirelessDeviceId": "57728ff8-5d1d-4130-9de2-f004d8722bc2",
+      "WirelessMetadata": {
+        "LoRaWAN": {
+          "DataRate": 0,
+          "DevEui": "aaaa1111bbbb2222",
+          "FPort": 2,
+          "Frequency": 867900000,
+          "Timestamp": "2020-12-07T14:41:48Z"
+        }
+      }
+    },
+    "output": {
+      "errorMessage": "Invalid response from meter",
+      "status": 500
+    }
   }
 ]

--- a/pulsedrop_direct/aws-iot-core/examples-aws-handler.json
+++ b/pulsedrop_direct/aws-iot-core/examples-aws-handler.json
@@ -83,7 +83,7 @@
       }
     },
     "output": {
-      "errorMessage": "No response from meter",
+      "errorMessage": "Error decoding:No response from meter",
       "status": 500
     }
   },
@@ -104,7 +104,7 @@
       }
     },
     "output": {
-      "errorMessage": "Invalid response from meter",
+      "errorMessage": "Error decoding:Invalid response from meter",
       "status": 500
     }
   }

--- a/pulsedrop_direct/aws-iot-core/index.js
+++ b/pulsedrop_direct/aws-iot-core/index.js
@@ -39,6 +39,8 @@ function decodeUplink(input) {
   // Constant factors for formulas
   const capacitorVoltageFactor = 5.0 / 255.0;
   const temperatureCelsiusFactor = 120.0 / 255.0;
+  const noResponseErrorFlag = 0x01;
+  const invalidResponseErrorFlag = 0x02;
 
   // Capacitor Voltage Scalar - 1 byte
   // 8-bit unsigned integer representing the capacitor voltage.
@@ -61,6 +63,19 @@ function decodeUplink(input) {
   if (capacitorVoltage < 2.5) {
     result.warnings.push(
       "Low capacitor voltage indicates depleted battery. System may cease operation soon."
+    );
+  }
+
+  // Digital AMI error flags
+  const errorFlags = raw[10];
+  if (errorFlags & noResponseErrorFlag) {
+    result.errors.push(
+      "No response from meter"
+    );
+  }
+  if (errorFlags & invalidResponseErrorFlag) {
+    result.errors.push(
+      "Invalid response from meter"
     );
   }
 

--- a/pulsedrop_direct/aws-iot-core/readme.md
+++ b/pulsedrop_direct/aws-iot-core/readme.md
@@ -23,9 +23,11 @@ Once again, please ensure that only Vutility PulseDrop data is invoking this Lam
 
 Every decoded packet will contain the following measurements in a json object.
 
+Note: Pulsedrop is available in conventional pulse counter and digital Advanced Meter Interface (AMI) variants. *(\*Still in development, contact Vutility sales)* The same data packet is used for both.
+
 | Name | Description | Units |
 | --- | --- | :---: |
-| `pulseCount` | The total pulses counted by device. | Count |
+| `pulseCount` | The total pulses counted **or** digital AMI meter reading. | Count |
 | `capacitorVoltage` | The capacitor voltage at time of transmit. | V |
 | `temperatureCelsius` | The temperature at time of transmit. | °C |
 
@@ -40,6 +42,30 @@ Example:
         "temperatureCelsius": 18.823529411764703
     },
     "errors": [],
+    "warnings": []
+}
+```
+### Digital AMI Error Flags
+Pulsedrops operating in Advanced Meter Interface (AMI) mode use a digital interface to directly read data from the attached meter. In the event that the meter does not respond or the data cannot be decoded by the Pulsedrop, the resulting data packet will contain error flags indicating the issue.
+
+In the event that a packet contains an error flag, the codec will indicate the issue in the "errors" field of the json packet and repeat the last known good data from the meter. (or zero if no previous read)
+
+| Error Flag | Cause | Resolution |
+| --- | --- | --- |
+| No response from meter | Poor or incorrect meter connections, dead meter battery. | Check meter connections and if meter is operational. |
+| Invalid response from meter | PulseDrop didn't understand the meter data. | Check compatibility of meter with PulseDrop |
+
+Example:
+```
+"output":
+{
+    "data":
+    {
+        "pulseCount": 0,
+        "capacitorVoltage": 3.8627450980392157,
+        "temperatureCelsius": 18.823529411764703
+    },
+    "errors": ["No response from meter"],
     "warnings": []
 }
 ```

--- a/pulsedrop_direct/chirpstack-v3/examples.json
+++ b/pulsedrop_direct/chirpstack-v3/examples.json
@@ -191,6 +191,7 @@
   {
     "type": "uplink",
     "description": "Error: no response from meter",
+    "expectException": true,
     "input": {
       "bytes": [
         28,
@@ -213,6 +214,7 @@
   {
     "type": "uplink",
     "description": "Error: invalid response from meter",
+    "expectException": true,
     "input": {
       "bytes": [
         28,

--- a/pulsedrop_direct/chirpstack-v3/examples.json
+++ b/pulsedrop_direct/chirpstack-v3/examples.json
@@ -189,6 +189,50 @@
     "errorMessage": "Payload packet ID is not equal to 28"
   },
   {
+    "type": "uplink",
+    "description": "Error: no response from meter",
+    "input": {
+      "bytes": [
+        28,
+        255,
+        17,
+        0,
+        0,
+        13,
+        232,
+        0,
+        0,
+        0,
+        1
+      ],
+      "fPort": 3,
+      "recvTime": "2023-05-02T20:00:00.000+00:00"
+    },
+    "errorMessage": "No response from meter"
+  },
+  {
+    "type": "uplink",
+    "description": "Error: invalid response from meter",
+    "input": {
+      "bytes": [
+        28,
+        255,
+        17,
+        0,
+        0,
+        13,
+        232,
+        0,
+        0,
+        0,
+        2
+      ],
+      "fPort": 3,
+      "recvTime": "2023-05-02T20:00:00.000+00:00"
+    },
+    "errorMessage": "Invalid response from meter"
+  },
+  {
     "type": "downlink-encode",
     "description": "downlink transmit interval (1 min)",
     "input": {

--- a/pulsedrop_direct/chirpstack-v3/index.js
+++ b/pulsedrop_direct/chirpstack-v3/index.js
@@ -31,6 +31,8 @@ function Decode(fPort, bytes, variables) {
   // Constant factors for formulas
   var capacitorVoltageFactor = 5.0 / 255.0;
   var temperatureCelsiusFactor = 120.0 / 255.0;
+  var noResponseErrorFlag = 0x01;
+  var invalidResponseErrorFlag = 0x02;
 
   // Capacitor Voltage Scalar - 1 byte
   // 8-bit unsigned integer representing the capacitor voltage.
@@ -54,6 +56,15 @@ function Decode(fPort, bytes, variables) {
   // Calculated fields
   var capacitorVoltage = capacitorVoltageFactor * capacitorVoltageScalar;
   var temperatureCelsius = temperatureCelsiusFactor * temperatureScalar - 40;
+
+  // Digital AMI error flags
+  const errorFlags = rawBytesArray[10];
+  if (errorFlags & noResponseErrorFlag) {
+    throw new Error("No response from meter");
+  }
+  if (errorFlags & invalidResponseErrorFlag) {
+    throw new Error("Invalid response from meter");
+  }
 
   result.data = {
     pulseCount: pulseCount,

--- a/pulsedrop_direct/chirpstack-v3/readme.md
+++ b/pulsedrop_direct/chirpstack-v3/readme.md
@@ -15,3 +15,5 @@ Once again, please ensure that only Vutility Pulsedrop are utilizing this device
 | `Encode`| ✅ | Equivalent to `encodeDownlink`. Only some downlinks are supported. Check the extended info for more details. |
 
 For more info on these functions please check the [ES5 readme](../index-es5-readme.md).
+
+**Note:** Unlike the ES5 version of the codec, Chirpstack V3 does not support error arrays in data. In the event of an issue there will only be a single error message returned.

--- a/pulsedrop_direct/chirpstack-v3/readme.md
+++ b/pulsedrop_direct/chirpstack-v3/readme.md
@@ -12,6 +12,6 @@ Once again, please ensure that only Vutility Pulsedrop are utilizing this device
 | Function | Available | Notes |
 | --- | --- | --- |
 | `Decode`| ✅ | Equivalent to `decodeUplink`|
-| `Encode`| ✅ | Equivalent to `encodeUplink`. Only some downlinks are supported. Check the extended info for more details. |
+| `Encode`| ✅ | Equivalent to `encodeDownlink`. Only some downlinks are supported. Check the extended info for more details. |
 
 For more info on these functions please check the [ES5 readme](../index-es5-readme.md).

--- a/pulsedrop_direct/examples.json
+++ b/pulsedrop_direct/examples.json
@@ -111,6 +111,42 @@
     }
   },
   {
+    "type": "uplink",
+    "description": "Error: no response from meter",
+    "input": {
+      "bytes": [28, 255, 17, 0, 0, 13, 232, 0, 0, 0, 1],
+      "fPort": 3,
+      "recvTime": "2023-05-02T20:00:00.000+00:00"
+    },
+    "output": {
+      "data": {
+        "pulseCount": 3560,
+        "capacitorVoltage": 5,
+        "temperatureCelsius": -32
+      },
+      "errors": ["No response from meter"],
+      "warnings": []
+    }
+  },
+  {
+    "type": "uplink",
+    "description": "Error: invalid response from meter",
+    "input": {
+      "bytes": [28, 255, 17, 0, 0, 13, 232, 0, 0, 0, 2],
+      "fPort": 3,
+      "recvTime": "2023-05-02T20:00:00.000+00:00"
+    },
+    "output": {
+      "data": {
+        "pulseCount": 3560,
+        "capacitorVoltage": 5,
+        "temperatureCelsius": -32
+      },
+      "errors": ["Invalid response from meter"],
+      "warnings": []
+    }
+  },
+  {
     "type": "downlink-encode",
     "description": "downlink transmit interval (1 min)",
     "input": {

--- a/pulsedrop_direct/index-es5-readme.md
+++ b/pulsedrop_direct/index-es5-readme.md
@@ -13,9 +13,11 @@ This codec targets ES5. If the desired environment does not support newer javasc
 
 Every decoded packet will contain the following measurements in a json object.
 
+Note: Pulsedrop is available in conventional pulse counter and digital Advanced Meter Interface (AMI) variants. *(\*Still in development, contact Vutility sales)* The same data packet is used for both.
+
 | Name | Description | Units |
 | --- | --- | :---: |
-| `pulseCount` | The total pulses counted by device. | Count |
+| `pulseCount` | The total pulses counted **or** digital AMI meter reading. | Count |
 | `capacitorVoltage` | The capacitor voltage at time of transmit. | V |
 | `temperatureCelsius` | The temperature at time of transmit. | °C |
 
@@ -30,6 +32,31 @@ Example:
         "temperatureCelsius": 18.823529411764703
     },
     "errors": [],
+    "warnings": []
+}
+```
+
+### Digital AMI Error Flags
+Pulsedrops operating in Advanced Meter Interface (AMI) mode use a digital interface to directly read data from the attached meter. In the event that the meter does not respond or the data cannot be decoded by the Pulsedrop, the resulting data packet will contain error flags indicating the issue.
+
+In the event that a packet contains an error flag, the codec will indicate the issue in the "errors" field of the json packet and repeat the last known good data from the meter. (or zero if no previous read)
+
+| Error Flag | Cause | Resolution |
+| --- | --- | --- |
+| No response from meter | Poor or incorrect meter connections, dead meter battery. | Check meter connections and if meter is operational. |
+| Invalid response from meter | PulseDrop didn't understand the meter data. | Check compatibility of meter with PulseDrop |
+
+Example:
+```
+"output":
+{
+    "data":
+    {
+        "pulseCount": 0,
+        "capacitorVoltage": 3.8627450980392157,
+        "temperatureCelsius": 18.823529411764703
+    },
+    "errors": ["No response from meter"],
     "warnings": []
 }
 ```

--- a/pulsedrop_direct/index-es5.js
+++ b/pulsedrop_direct/index-es5.js
@@ -44,6 +44,8 @@ function decodeUplink(input) {
   // Constant factors for formulas
   var capacitorVoltageFactor = 5.0 / 255.0;
   var temperatureCelsiusFactor = 120.0 / 255.0;
+  var noResponseErrorFlag = 0x01;
+  var invalidResponseErrorFlag = 0x02;
 
   // Capacitor Voltage Scalar - 1 byte
   // 8-bit unsigned integer representing the capacitor voltage.
@@ -71,6 +73,19 @@ function decodeUplink(input) {
   if (capacitorVoltage < 2.5) {
     result.warnings.push(
       "Low capacitor voltage indicates depleted battery. System may cease operation soon."
+    );
+  }
+
+  // Digital AMI error flags
+  const errorFlags = rawBytesArray[10];
+  if (errorFlags & noResponseErrorFlag) {
+    result.errors.push(
+      "No response from meter"
+    );
+  }
+  if (errorFlags & invalidResponseErrorFlag) {
+    result.errors.push(
+      "Invalid response from meter"
     );
   }
 

--- a/pulsedrop_direct/index-readme.md
+++ b/pulsedrop_direct/index-readme.md
@@ -11,9 +11,11 @@
 
 Every decoded packet will contain the following measurements in a json object.
 
+Note: Pulsedrop is available in conventional pulse counter and digital Advanced Meter Interface (AMI) variants. *(\*Still in development, contact Vutility sales)* The same data packet is used for both.
+
 | Name | Description | Units |
 | --- | --- | :---: |
-| `pulseCount` | The total pulses counted by device. | Count |
+| `pulseCount` | The total pulses counted **or** digital AMI meter reading. | Count |
 | `capacitorVoltage` | The capacitor voltage at time of transmit. | V |
 | `temperatureCelsius` | The temperature at time of transmit. | °C |
 
@@ -28,6 +30,31 @@ Example:
         "temperatureCelsius": 18.823529411764703
     },
     "errors": [],
+    "warnings": []
+}
+```
+
+### Digital AMI Error Flags
+Pulsedrops operating in Advanced Meter Interface (AMI) mode use a digital interface to directly read data from the attached meter. In the event that the meter does not respond or the data cannot be decoded by the Pulsedrop, the resulting data packet will contain error flags indicating the issue.
+
+In the event that a packet contains an error flag, the codec will indicate the issue in the "errors" field of the json packet and repeat the last known good data from the meter. (or zero if no previous read)
+
+| Error Flag | Cause | Resolution |
+| --- | --- | --- |
+| No response from meter | Poor or incorrect meter connections, dead meter battery. | Check meter connections and if meter is operational. |
+| Invalid response from meter | PulseDrop didn't understand the meter data. | Check compatibility of meter with PulseDrop |
+
+Example:
+```
+"output":
+{
+    "data":
+    {
+        "pulseCount": 0,
+        "capacitorVoltage": 3.8627450980392157,
+        "temperatureCelsius": 18.823529411764703
+    },
+    "errors": ["No response from meter"],
     "warnings": []
 }
 ```
@@ -87,8 +114,8 @@ Example:
 
 | Transmit Interval (s) | Raw Packet | Base64 Encoding | Default |
 | --- | --- | --- | :---: |
-| 60 | [54, 00, 00, 00, 70, 42, 00, 00, 00, 00] | VAAAAHBCAAAAAA== | ✅ |
+| 60 | [54, 00, 00, 00, 70, 42, 00, 00, 00, 00] | VAAAAHBCAAAAAA== | ❌ |
 | 120 | [54, 00, 00, 00, F0, 42, 00, 00, 00, 00] | VAAAAPBCAAAAAA== | ❌ |
-| 300 | [54, 00, 00, 00, 96, 43, 00, 00, 00, 00] | VAAAAJZDAAAAAA== | ❌ |
+| 300 (5 Minutes) | [54, 00, 00, 00, 96, 43, 00, 00, 00, 00] | VAAAAJZDAAAAAA== | ✅ |
 | 1500 | [54, 00, 00, 00, 61, 44, 00, 00, 00, 00] | VAAAAGFEAAAAAA== | ❌ |
 | 3000 | [54, 00, 00, 00, E1, 44, 00, 00, 00, 00] | VAAAAOFEAAAAAA== | ❌ |

--- a/pulsedrop_direct/index.js
+++ b/pulsedrop_direct/index.js
@@ -39,6 +39,8 @@ function decodeUplink(input) {
   // Constant factors for formulas
   const capacitorVoltageFactor = 5.0 / 255.0;
   const temperatureCelsiusFactor = 120.0 / 255.0;
+  const noResponseErrorFlag = 0x01;
+  const invalidResponseErrorFlag = 0x02;
 
   // Capacitor Voltage Scalar - 1 byte
   // 8-bit unsigned integer representing the capacitor voltage.
@@ -61,6 +63,19 @@ function decodeUplink(input) {
   if (capacitorVoltage < 2.5) {
     result.warnings.push(
       "Low capacitor voltage indicates depleted battery. System may cease operation soon."
+    );
+  }
+
+  // Digital AMI error flags
+  const errorFlags = raw[10];
+  if (errorFlags & noResponseErrorFlag) {
+    result.errors.push(
+      "No response from meter"
+    );
+  }
+  if (errorFlags & invalidResponseErrorFlag) {
+    result.errors.push(
+      "Invalid response from meter"
     );
   }
 

--- a/pulsedrop_direct/package.json
+++ b/pulsedrop_direct/package.json
@@ -10,6 +10,6 @@
   "author": "Vutility",
   "license": "ISC",
   "devDependencies": {
-    "jest": "^29.5.0"
+    "jest": "^29.7.0"
   }
 }


### PR DESCRIPTION
Add decoding AMI error flags. I chose to put them in the "errors" field but still return the pulse data as the meter will send the last known good info. 

Please take a look at the readme's and let me know if they look good.


```
--------------------------------|---------|----------|---------|---------|-------------------
File                            | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s
--------------------------------|---------|----------|---------|---------|-------------------
All files                       |     100 |      100 |     100 |     100 |
 pulsedrop_direct               |     100 |      100 |     100 |     100 |
  index-es5.js                  |     100 |      100 |     100 |     100 |
  index.js                      |     100 |      100 |     100 |     100 |
 pulsedrop_direct/aws-iot-core  |     100 |      100 |     100 |     100 |
  index.js                      |     100 |      100 |     100 |     100 |
 pulsedrop_direct/chirpstack-v3 |     100 |      100 |     100 |     100 |
  index.js                      |     100 |      100 |     100 |     100 |
--------------------------------|---------|----------|---------|---------|-------------------

Test Suites: 4 passed, 4 total
Tests:       88 passed, 88 total
Snapshots:   0 total
Time:        0.163 s, estimated 1 s
Ran all test suites.
```